### PR TITLE
Updated docs to support API server & default ingress certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Manually ignored files
+
+*.ignore*
+
 #  Local .terraform directories
 **/.terraform/*
 .terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Terraform module to create letsencrypt certificates for various DNS providers
 
 Check sample tfvars file in [examples](https://github.com/ncolon/terraform-certs-letsencrypt/tree/main/examples) folder. Copy one of the files to the root folder and replace parameters with your values.
 
+## Replacing OpenShift default ingress certificates
+
+Your `app_subdomain` variable should be like: `apps.openshift.example.com` ([Documentation](https://docs.openshift.com/container-platform/4.8/security/certificates/replacing-default-ingress-certificate.html)).
+
 ```bash
 # Run terraform
 $ terraform init
@@ -15,7 +19,15 @@ $ terraform output --raw router_cert > router.crt
 $ terraform output --raw router_key > router.key
 $ terraform output --raw router_ca > router-ca.crt
 
-# Apply Certificates to OpenShift Cluster
+# Create a config map that includes only the root CA certificate used to sign the wildcard certificate
+$ oc create configmap custom-ca \
+     --from-file=ca-bundle.crt=router-ca.crt \
+     -n openshift-config
+# Update the cluster-wide proxy configuration with the newly created config map
+$ oc patch proxy/cluster \
+     --type=merge \
+     --patch='{"spec":{"trustedCA":{"name":"custom-ca"}}}'
+# Create a secret that contains the wildcard certificate chain and key
 $ oc create secret tls letsencrypt-certs \
     --cert=router.crt \
     --key=router.key \
@@ -24,17 +36,33 @@ $ oc patch ingresscontroller.operator default \
     --type=merge -p \
     '{"spec":{"defaultCertificate": {"name": "letsencrypt-certs"}}}' \
     -n openshift-ingress-operator
-
-$ cat << EOF > user-ca-bundle.yaml
-apiVersion: v1
-kind: ConfigMap
-data:
-  ca-bundle.crt: |
-$(cat router-ca.crt | sed 's/^/    /')
-metadata:
-  name: user-ca-bundle
-  namespace: openshift-config
-EOF
-$ oc apply -f user-ca-bundle.yaml
-$ oc patch proxy cluster --type=merge -p '{"spec": {"trustedCA": {"name": "user-ca-bundle"}}}'
 ```
+
+## Replacing OpenShift default API server certificates
+
+Your `app_subdomain` variable should be like: `api.openshift.example.com` ([Documentation](https://docs.openshift.com/container-platform/4.8/security/certificates/api-server.html)).
+
+```bash
+# Run terraform
+$ terraform init
+$ terraform plan
+$ terraform apply
+
+# Get Certificates
+$ terraform output --raw router_cert > router.crt
+$ terraform output --raw router_ca >> router.crt
+$ terraform output --raw router_key > router.key
+
+# Create a secret that contains the certificate chain and private key in the openshift-config namespace
+$ oc create secret tls api-server-certs \
+     --cert=router.crt \
+     --key=router.key \
+     -n openshift-config
+# Update the API server to reference the created secret.
+$ oc patch apiserver cluster \
+     --type=merge -p \
+     '{"spec":{"servingCerts": {"namedCertificates":
+     [{"names": ["<FQDN>"], 
+     "servingCertificate": {"name": "api-server-certs"}}]}}}'
+```
+ - **Note**: replace `<FQDN>` in this example it would be `api.openshift.example.com`.


### PR DESCRIPTION
Updated docs to support API server certs replacement as well as default OpenShift ingress.

Signed-off-by: Noé Samaille <noe.samaille@ibm.com>